### PR TITLE
Try to guess a mime type when serving static files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "react/event-loop": "^1",
         "react/socket": "^1",
         "react/promise": "^2",
-        "react/filesystem": "*"
+        "react/filesystem": "*",
+        "narrowspark/mimetypes": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.0",

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -26,6 +26,7 @@ namespace Apisearch\SymfonyReactServer;
  * @author Marc Morera <yuhu@mmoreram.com>
  */
 
+use Narrowspark\MimeType\MimeTypeFileExtensionGuesser;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Filesystem\FilesystemInterface;
 use React\Promise;
@@ -175,7 +176,7 @@ class RequestHandler
                     new \React\Http\Response(
                         200,
                         [
-                            'Content-Type' => mime_content_type($rootPath . $resourcePath)
+                            'Content-Type' => MimeTypeFileExtensionGuesser::guess($rootPath . $resourcePath)
                         ],
                         $contents
                     ),


### PR DESCRIPTION
When working with files asynchronously we can't use native PHP
functions. Instead, try to guess a mime type comparing it with
a predefined list of extensions.