### PR TITLE
Make mime type detection async

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "react/event-loop": "^1",
         "react/socket": "^1",
         "react/promise": "^2",
-        "react/filesystem": "*"
+        "react/filesystem": "*",
+        "mmoreram/react-functions": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "apisearch-io/symfony-async-http-kernel": "dev-master",
         "symfony/framework-bundle": "^4.2",
         "symfony/process": "^4.2",
-        "symfony/config": "^4.2"
+        "symfony/config": "^4.2",
+        "ext-fileinfo": "*"
     },
     "suggest": {
         "apisearch-io/symfony-async-http-kernel": "To enable --non-blocking flag and work with Async Kernel"

--- a/src/Application.php
+++ b/src/Application.php
@@ -187,8 +187,8 @@ class Application
         }
 
         $http = new HttpServer(
-            function (ServerRequestInterface $request) use ($requestHandler, $filesystem) {
-                return new Promise(function (Callable $resolve) use ($request, $requestHandler, $filesystem) {
+            function (ServerRequestInterface $request) use ($requestHandler, $filesystem, $loop) {
+                return new Promise(function (Callable $resolve) use ($request, $requestHandler, $filesystem, $loop) {
 
                     $resolveResponseCallback = function(ServerResponseWithMessage $serverResponseWithMessage) use ($resolve) {
                         if (!$this->silent) {
@@ -206,6 +206,7 @@ class Application
                         $this->staticFolder
                     ) === 0) {
                         $requestHandler->handleStaticResource(
+                            $loop,
                             $filesystem,
                             $this->rootPath,
                             $uriPath

--- a/tests/ApplicationStaticFolderTest.php
+++ b/tests/ApplicationStaticFolderTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Apisearch\SymfonyReactServer\Tests;
 
+use finfo;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -47,11 +48,7 @@ class ApplicationStaticFolderTest extends TestCase
             ) > 0
         );
 
-        $content = file_get_contents('http://localhost:9999/tests/public/app.js');
-        $this->assertEquals(
-            '// Some app',
-            $content
-        );
+        $this->assertFileWasReceived('http://localhost:9999/tests/public/app.js', '// Some app', 'text/plain');
         usleep(100000);
 
         $this->assertNotFalse(
@@ -93,5 +90,14 @@ class ApplicationStaticFolderTest extends TestCase
         $this->assertFalse($content);
 
         $process->stop();
+    }
+
+    private function assertFileWasReceived(string $file, string $expectedContent, string $expectedMimeType): void
+    {
+        $content = file_get_contents($file);
+        $this->assertEquals($expectedContent, $content);
+
+        $fileInfo = new Finfo(FILEINFO_MIME_TYPE);
+        $this->assertEquals($expectedMimeType, $fileInfo->buffer($content));
     }
 }


### PR DESCRIPTION
We asynchronously get the contents of the file and its mime type. Once both promises are resolved we return a response.

[The previous implementation](https://github.com/apisearch-io/symfony-react-server/pull/5) was cancelled in order to make it reliable and truly asynchronous.
