### PR TITLE
Use php-watcher in dev environment

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -62,8 +62,28 @@ function requireIfExists(string $file)
     return null;
 }
 
+function initializeWatcher(\React\EventLoop\LoopInterface $loop, \Apisearch\SymfonyReactServer\Application $application) {
+    $watchList = new \seregazhuk\PhpWatcher\Config\WatchList(['config', 'src'], ['php', 'yml', 'yaml', 'xml']);
+    $output = new Symfony\Component\Console\Style\SymfonyStyle(
+        new \Symfony\Component\Console\Input\ArgvInput(),
+        new \Symfony\Component\Console\Output\ConsoleOutput()
+    );
+    $screen = new \seregazhuk\PhpWatcher\Screen\Screen($output);
+    $screen->showSpinner($loop);
+    $filesystemListener = new seregazhuk\PhpWatcher\Filesystem\ChangesListener($loop, $watchList);
+
+    $filesystemListener->on('change', static function () use ($application, $screen) {
+        $screen->restarting();
+        $application->stop();
+        $application->run();
+    });
+
+    $filesystemListener->start();
+}
+
 use Apisearch\SymfonyReactServer\Adapter\KernelAdapter;
 use Apisearch\SymfonyReactServer\Adapter\Symfony4KernelAdapter;
+use React\EventLoop\Factory as EventLoopFactory;
 
 /**
  * Server.
@@ -102,6 +122,8 @@ if (!is_a($adapter, KernelAdapter::class, true)) {
     die('You must define an existing kernel adapter, or by an alias or my a namespace. This class MUST implement KernelAdapter' . PHP_EOL);
 }
 
+$loop = EventLoopFactory::create();
+
 $application = new \Apisearch\SymfonyReactServer\Application(
     $rootPath,
     $host,
@@ -112,7 +134,13 @@ $application = new \Apisearch\SymfonyReactServer\Application(
     $nonBlocking,
     $adapter,
     $bootstrapFile,
-    $staticFolder
+    $staticFolder,
+    $loop
 );
 
+if ($environment === 'dev') {
+    initializeWatcher($loop, $application);
+}
+
 $application->run();
+$loop->run();

--- a/bin/server
+++ b/bin/server
@@ -62,27 +62,9 @@ function requireIfExists(string $file)
     return null;
 }
 
-function initializeWatcher(\React\EventLoop\LoopInterface $loop, \Apisearch\SymfonyReactServer\Application $application) {
-    $watchList = new \seregazhuk\PhpWatcher\Config\WatchList(['config', 'src'], ['php', 'yml', 'yaml', 'xml']);
-    $output = new Symfony\Component\Console\Style\SymfonyStyle(
-        new \Symfony\Component\Console\Input\ArgvInput(),
-        new \Symfony\Component\Console\Output\ConsoleOutput()
-    );
-    $screen = new \seregazhuk\PhpWatcher\Screen\Screen($output);
-    $screen->showSpinner($loop);
-    $filesystemListener = new seregazhuk\PhpWatcher\Filesystem\ChangesListener($loop, $watchList);
-
-    $filesystemListener->on('change', static function () use ($application, $screen) {
-        $screen->restarting();
-        $application->stop();
-        $application->run();
-    });
-
-    $filesystemListener->start();
-}
-
 use Apisearch\SymfonyReactServer\Adapter\KernelAdapter;
 use Apisearch\SymfonyReactServer\Adapter\Symfony4KernelAdapter;
+use Apisearch\SymfonyReactServer\ChangesWatcher;
 use React\EventLoop\Factory as EventLoopFactory;
 
 /**
@@ -138,8 +120,9 @@ $application = new \Apisearch\SymfonyReactServer\Application(
     $loop
 );
 
-if ($environment === 'dev') {
-    initializeWatcher($loop, $application);
+if ($environment === 'dev' && ChangesWatcher::isAvailable()) {
+    $watcher = new ChangesWatcher($loop);
+    $watcher->watch($application);
 }
 
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/framework-bundle": "^4.2",
         "symfony/process": "^4.2",
         "symfony/config": "^4.2",
-        "ext-fileinfo": "*"
+        "ext-fileinfo": "*",
+        "seregazhuk/php-watcher": "dev-master"
     },
     "suggest": {
         "apisearch-io/symfony-async-http-kernel": "To enable --non-blocking flag and work with Async Kernel"

--- a/src/ChangesWatcher.php
+++ b/src/ChangesWatcher.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Apisearch\SymfonyReactServer;
+
+use React\EventLoop\LoopInterface;
+use seregazhuk\PhpWatcher\Config\WatchList;
+use seregazhuk\PhpWatcher\Filesystem\ChangesListener;
+use seregazhuk\PhpWatcher\Screen\Screen;
+use seregazhuk\PhpWatcher\Screen\SpinnerFactory;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class ChangesWatcher
+{
+    private const DIRECTORIES = ['config', 'src'];
+    private const EXTENSIONS = ['php', 'yml', 'yaml', 'xml'];
+
+    private $loop;
+    private $watchList;
+    private $screen;
+
+    public static function isAvailable(): bool
+    {
+        return class_exists('\seregazhuk\PhpWatcher\Config\WatchList');
+    }
+
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+        $this->watchList = new WatchList(self::DIRECTORIES, self::EXTENSIONS);
+        $output = new SymfonyStyle(new ArgvInput(), new ConsoleOutput());
+        $this->screen = new Screen($output, SpinnerFactory::create($output, false));
+    }
+
+    public function watch(Application $application): void
+    {
+        $this->screen->showSpinner($this->loop);
+        $filesystemListener = new ChangesListener($this->loop, $this->watchList);
+
+        $filesystemListener->on('change', function () use ($application) {
+            $this->restartApplication($application);
+        });
+
+        $filesystemListener->start();
+    }
+
+    private function restartApplication(Application $application): void
+    {
+        $this->screen->restarting();
+        $application->stop();
+        $application->run();
+    }
+}


### PR DESCRIPTION
When running in `dev` environment uses [PHP-Watcher](https://github.com/seregazhuk/php-watcher) to reload the server once the source code changes. Listens for changes in `config` and `src` folders and `php, yml` files.

This is how it looks like:

[![asciicast](https://asciinema.org/a/276698.svg)](https://asciinema.org/a/276698)

I'm not sure if I'm stopping the app correctly 🤔 I've removed all listeners, closed the socket and stopped the kernel. Maybe I've missed something here?